### PR TITLE
Fixed regex in cdlatex-tab to support \(...\)

### DIFF
--- a/cdlatex.el
+++ b/cdlatex.el
@@ -889,7 +889,7 @@ Sounds strange?  Try it out!"
                  (forward-char 1)
                  (delete-char 1))
         (forward-char 4))
-      (if (looking-at "[^_\\^({\\[]")
+      (if (looking-at "[^_^({[]")
           ;; stop after closing bracket, unless ^_[{( follow
           (throw 'stop t)))
      ((= (following-char) ?$)


### PR DESCRIPTION
This should solve #8. I'm not sure if the way emacs handles regexps has changed at some point, but this change makes it do what the nearby comment says.