### PR TITLE
Added `text` macro in math modify menu

### DIFF
--- a/cdlatex.el
+++ b/cdlatex.el
@@ -1528,6 +1528,7 @@ zZ
     ( ?v    "\\check"             nil        t   t   nil )
     ( ?u    "\\breve"             nil        t   t   nil )
     ( ?m    "\\mbox"              nil        t   nil nil )
+    ( ?t    "\\text"              nil        t   nil nil )    
     ( ?c    "\\mathcal"           nil        t   nil nil )
     ( ?r    "\\mathrm"            "\\textrm" t   nil nil )
     ( ?i    "\\mathit"            "\\textit" t   nil nil )


### PR DESCRIPTION
Using the shortcut `'t` one can insert text inside equations. 
The `text` macro is the preferable way of inserting text, better than `mbox` or `mathrm`, see [discussion](https://tex.stackexchange.com/questions/88730/mathrm-or-mbox-what-is-the-convention-when-writing-a-equation).