### PR TITLE
Remove obsolete no-op functions calls

### DIFF
--- a/cdlatex.el
+++ b/cdlatex.el
@@ -682,13 +682,10 @@ Entering cdlatex-mode calls the hook cdlatex-mode-hook.
                              (<= (prefix-numeric-value arg) 0))))
 
   ; Add or remove the menu, and run the hook
-  (if cdlatex-mode
-      (progn
-	(easy-menu-add cdlatex-mode-menu)
-	(run-hooks 'cdlatex-mode-hook)
-	(cdlatex-compute-tables))
-    (easy-menu-remove cdlatex-mode-menu)))
-    
+  (when cdlatex-mode
+    (run-hooks 'cdlatex-mode-hook)
+    (cdlatex-compute-tables))
+
 (or (assoc 'cdlatex-mode minor-mode-alist)
     (setq minor-mode-alist
           (cons '(cdlatex-mode " CDL") minor-mode-alist)))


### PR DESCRIPTION
Functions `easy-menu-add' and `easy-menu-remove' have been for quite
some time no-op functions in Emacs, aliased to `ignore'. As of Emacs
28, they are now obsolete and should be removed.

This commit removes the usage of these two functions and converts the
`if' that contained them to a `when'. This also removes the need for
the `progn'.