### PR TITLE
Adding a template for unnumbered equation

### DIFF
--- a/cdlatex.el
+++ b/cdlatex.el
@@ -1497,7 +1497,9 @@ zZ
      "" cdlatex-environment ("enumerate") t nil)
     ("equ"       "Insert an EQUATION environment template"
      "" cdlatex-environment ("equation") t nil)
-    ("eqn"       "Insert an EQUATION environment template"
+    ("eq*"       "Insert an EQUATION* environment template"
+     "" cdlatex-environment ("equation*") t nil)
+    ("eqn"       "Insert an EQNARRAY environment template"
      "" cdlatex-environment ("eqnarray") t nil)
     ("ali"       "Insert an ALIGN environment template"
      "" cdlatex-environment ("align") t nil)


### PR DESCRIPTION
Proposing the addition of a template for the environment `equation*`, I suggested the use of the key `eq*`.

A typo for the template of `eqnarray` was also corrected.