### PR TITLE
Math modifier for `mathfrak`

### DIFF
--- a/cdlatex.el
+++ b/cdlatex.el
@@ -1612,6 +1612,7 @@ zZ
     ( ?e    "\\mathem"            "\\emph"   t   nil nil )
     ( ?y    "\\mathtt"            "\\texttt" t   nil nil )
     ( ?f    "\\mathsf"            "\\textsf" t   nil nil )
+    ( ?F    "\\mathfrak"          nil        t   nil nil )
     ( ?0    "\\textstyle"         nil        nil nil nil )
     ( ?1    "\\displaystyle"      nil        nil nil nil )
     ( ?2    "\\scriptstyle"       nil        nil nil nil )


### PR DESCRIPTION
The Gothic characters are widely used in mathematical texts.  I propose to add a modifier to expand these character, using the key `F`