### PR TITLE
Fix cdlatex-math-symbol-no-of-levels computation

### DIFF
--- a/cdlatex.el
+++ b/cdlatex.el
@@ -2202,9 +2202,8 @@ and after changes to these variables via
 
   ;; find out how many levels are needed for the math symbol stuff
   (let ((maxlev 0) (list cdlatex-math-symbol-alist-comb))
-    (while (> (length list) 0)
-      (setq maxlev (max maxlev (length (nth 0 list)))
-            list (cdr list)))
+    (while list
+      (setq maxlev (max maxlev (length (pop list)))))
     (setq cdlatex-math-symbol-no-of-levels (1- maxlev)))
 
   ;; The direct key bindings.

--- a/cdlatex.el
+++ b/cdlatex.el
@@ -2202,8 +2202,8 @@ and after changes to these variables via
 
   ;; find out how many levels are needed for the math symbol stuff
   (let ((maxlev 0) (list cdlatex-math-symbol-alist-comb))
-    (while (pop list)
-      (setq maxlev (max maxlev (length (nth 1 list)))
+    (while (> (length list) 0)
+      (setq maxlev (max maxlev (length (nth 0 list)))
             list (cdr list)))
     (setq cdlatex-math-symbol-no-of-levels (1- maxlev)))
 


### PR DESCRIPTION
In the original code, it would first pop the list, and then directly take the 1st instead of the 0th item from the remaining entries, causing some entries to be skipped when calculating cdlatex-math-symbol-no-of-levels.
