### PR TITLE
Remove backslash from regex in cdlatex-tab

### DIFF
--- a/cdlatex.el
+++ b/cdlatex.el
@@ -1006,7 +1006,7 @@ Sounds strange?  Try it out!"
                 (= (preceding-char) ?-))
             (throw 'stop t)
           (forward-char 1)
-          (if (looking-at "[^_\\^({\\[]")
+          (if (looking-at "[^_^({[]")
               ;; stop after closing bracket, unless ^_[{( follow
               (throw 'stop t))))))))
 


### PR DESCRIPTION
Fixes #65 